### PR TITLE
Take the correct location for move score

### DIFF
--- a/KaribaPlayer.py
+++ b/KaribaPlayer.py
@@ -27,8 +27,8 @@ class KaribaPlayer:
             return 0
         if loc == 1:
             return board[7]
-        loc -= 1
-        while loc > 0:
+        loc -= 2
+        while loc >= 0:
             if board[loc] > 0:
                 return board[loc]
             loc -=1


### PR DESCRIPTION
Before this change the taken location was wrongly allowed to be identical to the move location. Furthermore, it ignored cards at location 1.
GreedyPlayer4 with this change vs GreedyPlayer4 without it: 1080:920.
A similar improvement is achieved compared to other players.